### PR TITLE
keymap.lua中添加终端buffer的关闭快捷键

### DIFF
--- a/lua/keymap.lua
+++ b/lua/keymap.lua
@@ -128,6 +128,7 @@ G.map({
 
     -- tt 打开一个10行大小的终端
     { 'n', 'tt',          ':below 10sp | term<cr>a',                          { noremap = true, silent = true } },
+    { 't', 'tw',          '<c-\\><c-n>:q!<cr>',                               { noremap = true, silent = true } },
 
     -- 切换是否wrap
     { 'n', '\\w',         "&wrap == 1 ? ':set nowrap<cr>' : ':set wrap<cr>'", { noremap = true, expr = true } },


### PR DESCRIPTION
感谢提供的这么好的资源和教程. 作为新手学到很多东西!!!

通过tw快捷键可以关闭打开的终端buffer
{ 't', 'tw',   '<c-\\><c-n>:q!<cr>',  { noremap = true, silent = true } },